### PR TITLE
Add stlinkv2 as upload protocol for stm8sblue

### DIFF
--- a/boards/stm8sblue.json
+++ b/boards/stm8sblue.json
@@ -16,7 +16,8 @@
     "maximum_size": 8192,
     "protocol": "serial",
     "protocols": [
-      "serial"
+        "serial",
+        "stlinkv2"
     ]
   },
   "name": "ST STM8S103F3 Breakout Board",


### PR DESCRIPTION
Somehow the stlinkv2 was missing for this particular board.

Btw, how can you select a programmer for uploading? Writing `upload_protocol = stlinkv2` in `platformio.ini` gets me this far:

```
Configuring upload protocol...
AVAILABLE: serial, stlinkv2
CURRENT: upload_protocol = stlinkv2
Uploading .pioenvs\stm8sblue\firmware.ihx
No valid programmer specified. Possible values are:
stlink
stlinkv2
stlinkv21
stlinkv3
*** [upload] Error -1
```