### PR TITLE
Add Nucleo-8S207K8 and Nucleo-8S208RB support

### DIFF
--- a/boards/nucleo_8s207k8.json
+++ b/boards/nucleo_8s207k8.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "sduino",
+    "extra_flags": "-DSTM8S_NUCLEO_207K8 -DSTM8S207",
+    "f_cpu": "16000000L",
+    "cpu": "stm8",
+    "mcu": "stm8s207k8t6"
+  },
+  "frameworks": [
+    "spl"
+  ],
+  "upload": {
+    "maximum_ram_size": 6144,
+    "maximum_size": 65536,
+    "protocol": "stlinkv21",
+    "protocols": [
+      "stlinkv21",
+      "serial"
+    ],
+    "stm8flash_target": "stm8s207k8"
+  },
+  "name": "NUCLEO-8S207K8",
+  "url": "https://www.st.com/en/evaluation-tools/nucleo-8s207k8.html",
+  "vendor": "STMicroelectronics"
+}

--- a/boards/nucleo_8s208rb.json
+++ b/boards/nucleo_8s208rb.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "sduino",
+    "extra_flags": "-DSTM8S_NUCLEO_208RB -DSTM8S208",
+    "f_cpu": "16000000L",
+    "cpu": "stm8",
+    "mcu": "stm8s208rbt6"
+  },
+  "frameworks": [
+    "spl"
+  ],
+  "upload": {
+    "maximum_ram_size": 6144,
+    "maximum_size": 131072,
+    "protocol": "stlinkv21",
+    "protocols": [
+      "stlinkv21",
+      "serial"
+    ]
+  },
+  "name": "NUCLEO-8S208RB",
+  "url": "https://www.st.com/en/evaluation-tools/nucleo-8s208rb.html",
+  "vendor": "STMicroelectronics"
+}

--- a/builder/main.py
+++ b/builder/main.py
@@ -148,11 +148,14 @@ if upload_protocol == "serial":
 
 elif "stlink" in upload_protocol:
     mcu = board_config.get("build.mcu")
+    # either derive value for the "part" switch from MCU name, or use the value 
+    # in the board manifest, in cases in which the derivation would be wrong.
+    flash_target = board_config.get("upload.stm8flash_target", mcu[:8] + "?" + mcu[9])
     env.Replace(
         UPLOADER="stm8flash",
         UPLOADERFLAGS=[
             "-c", "$UPLOAD_PROTOCOL",
-            "-p", "%s" % mcu[:8] + "?" + mcu[9],
+            "-p", "%s" % flash_target,
             "-s", "flash", "-w"
         ],
         UPLOADCMD='"$UPLOADER" $UPLOADERFLAGS $SOURCE'

--- a/examples/spl-blink/platformio.ini
+++ b/examples/spl-blink/platformio.ini
@@ -21,3 +21,13 @@ board = s8uno
 platform = ststm8
 framework = spl
 board = mb208
+
+[env:nucleo_8s207k8]
+platform = ststm8
+board = nucleo_8s207k8
+framework = spl
+
+[env:nucleo_8s208rb]
+platform = ststm8
+board = nucleo_8s208rb
+framework = spl

--- a/examples/spl-blink/src/main.c
+++ b/examples/spl-blink/src/main.c
@@ -38,8 +38,14 @@
 /* Private define ------------------------------------------------------------*/
 /* Evalboard I/Os configuration */
 
+/* automatically use built-in LED for known nucleo boards */
+#if defined(STM8S_NUCLEO_208RB) || defined(STM8S_NUCLEO_207K8) 
+#define LED_GPIO_PORT  (GPIOC)
+#define LED_GPIO_PINS  (GPIO_PIN_5)
+#else
 #define LED_GPIO_PORT  (GPIOG)
 #define LED_GPIO_PINS  (GPIO_PIN_3 | GPIO_PIN_2 | GPIO_PIN_1 | GPIO_PIN_0)
+#endif
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/


### PR DESCRIPTION
Closes #33 and #34. 

Tested during a personal exchange with @gicking.

The `builder/main.py` had to be modified because PIO would do an invocation with `stm8flash -p stm8s207?8` which STM8Flash doesn't know

>\>stm8flash.exe -l
stlux385 stlux???a stm8af526? stm8af528? stm8af52a? stm8af6213 stm8af6223 stm8af6223a stm8af6226 stm8af624? stm8af6266 stm8af6268 stm8af6269 stm8af628? stm8af62a? stm8al313? stm8al314? stm8al316? stm8al318? stm8al31e8? stm8al3l4? stm8al3l6? stm8al3l8? stm8al3le8? stm8l001j3 stm8l050j3 stm8l051f3 stm8l052c6 stm8l052r8 stm8l101f1 stm8l101?2 stm8l101?3 stm8l151?2 stm8l151?3 stm8l151?4 stm8l151?6 stm8l151?8 stm8l152?4 stm8l152?6 stm8l152?8 stm8l162?8 stm8s001j3 stm8s003?3 stm8s005?6 stm8s007c8 stm8s103f2 stm8s103?3 stm8s105?4 stm8s105?6 stm8s207c8 stm8s207cb stm8s207k8 stm8s207m8 stm8s207mb stm8s207r8 stm8s207rb stm8s207s8 stm8s207sb stm8s207?6 stm8s208c6 stm8s208r6 stm8s208s6 stm8s208?8 stm8s208?b stm8s903?3 stm8splnb1 stm8tl5??4 stnrg???a

Since it should have been `stm8s207rb`. 

SPL examples and flashing them are confirmed working on the real boards. 