### PR TITLE
Disable all SPL modules but GPIO for spl-blink

### DIFF
--- a/examples/spl-blink/README.rst
+++ b/examples/spl-blink/README.rst
@@ -36,3 +36,8 @@ How to build PlatformIO based project
 
     # Clean build files
     > platformio run --target clean
+
+Notes regarding SPL setup
+=========================
+
+Please see the `src/stm8s_conf.h` file for activating more SPL modules, if you wish to expand the functionality of this example. Only modules (like ADC, UART, etc.) that are activated in the configuration file are compiled in. In this example, only the GPIO module is active. Activating unused modules will result in a higher flash usage that will make even compilation even impossible for smaller chips, to care must be taken.

--- a/examples/spl-blink/platformio.ini
+++ b/examples/spl-blink/platformio.ini
@@ -31,3 +31,8 @@ framework = spl
 platform = ststm8
 board = nucleo_8s208rb
 framework = spl
+
+[env:stm8sblue]
+platform = ststm8
+board = stm8sblue
+framework = spl

--- a/examples/spl-blink/src/main.c
+++ b/examples/spl-blink/src/main.c
@@ -42,7 +42,12 @@
 #if defined(STM8S_NUCLEO_208RB) || defined(STM8S_NUCLEO_207K8) 
 #define LED_GPIO_PORT  (GPIOC)
 #define LED_GPIO_PINS  (GPIO_PIN_5)
-#else
+#elif defined(STM8S103)
+/* for STM8S103F3 breakout board. building with GPIOG would result in failure (chip 
+ * does not have that GPIO peripheral) */
+#define LED_GPIO_PORT  (GPIOB)
+#define LED_GPIO_PINS  (GPIO_PIN_5)	
+#else 
 #define LED_GPIO_PORT  (GPIOG)
 #define LED_GPIO_PINS  (GPIO_PIN_3 | GPIO_PIN_2 | GPIO_PIN_1 | GPIO_PIN_0)
 #endif

--- a/examples/spl-blink/src/stm8s_conf.h
+++ b/examples/spl-blink/src/stm8s_conf.h
@@ -37,56 +37,56 @@
 /* Uncomment the line below to enable peripheral header file inclusion */
 #if defined(STM8S105) || defined(STM8S005) || defined(STM8S103) || defined(STM8S003) ||\
     defined(STM8S001) || defined(STM8S903) || defined (STM8AF626x) || defined (STM8AF622x)
-#include "stm8s_adc1.h" 
+//#include "stm8s_adc1.h" 
 #endif /* (STM8S105) ||(STM8S103) || (STM8S001) || (STM8S903) || (STM8AF626x) */
 #if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined (STM8AF52Ax) ||\
     defined (STM8AF62Ax)
- #include "stm8s_adc2.h"
+// #include "stm8s_adc2.h"
 #endif /* (STM8S208) || (STM8S207) || (STM8AF62Ax) || (STM8AF52Ax) */
-#include "stm8s_awu.h"
-#include "stm8s_beep.h"
+//#include "stm8s_awu.h"
+//#include "stm8s_beep.h"
 #if defined (STM8S208) || defined (STM8AF52Ax)
- #include "stm8s_can.h"
+// #include "stm8s_can.h"
 #endif /* (STM8S208) || (STM8AF52Ax) */
-#include "stm8s_clk.h"
-#include "stm8s_exti.h"
-#include "stm8s_flash.h"
+//#include "stm8s_clk.h"
+//#include "stm8s_exti.h"
+//#include "stm8s_flash.h"
 #include "stm8s_gpio.h"
-#include "stm8s_i2c.h"
-#include "stm8s_itc.h"
-#include "stm8s_iwdg.h"
-#include "stm8s_rst.h"
-#include "stm8s_spi.h"
-#include "stm8s_tim1.h"
+//#include "stm8s_i2c.h"
+//#include "stm8s_itc.h"
+//#include "stm8s_iwdg.h"
+//#include "stm8s_rst.h"
+//#include "stm8s_spi.h"
+//#include "stm8s_tim1.h"
 #if !defined(STM8S903) && !defined(STM8AF622x)   /* SDCC patch: see https://github.com/tenbaht/sduino/tree/master/STM8S_StdPeriph_Driver */
- #include "stm8s_tim2.h"
+// #include "stm8s_tim2.h"
 #endif /* (STM8S903) || (STM8AF622x) */
 #if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) ||defined(STM8S105) ||\
     defined(STM8S005) ||  defined (STM8AF52Ax) || defined (STM8AF62Ax) || defined (STM8AF626x)
- #include "stm8s_tim3.h"
+// #include "stm8s_tim3.h"
 #endif /* (STM8S208) || (STM8S207) || (STM8S007) || (STM8S105) */ 
 #if !defined(STM8S903) && !defined(STM8AF622x)   /* SDCC patch: see https://github.com/tenbaht/sduino/tree/master/STM8S_StdPeriph_Driver */
- #include "stm8s_tim4.h"
+// #include "stm8s_tim4.h"
 #endif /* (STM8S903) || (STM8AF622x) */
 #if defined(STM8S903) || defined(STM8AF622x)     /* SDCC patch: see https://github.com/tenbaht/sduino/tree/master/STM8S_StdPeriph_Driver */
- #include "stm8s_tim5.h"
- #include "stm8s_tim6.h"
+// #include "stm8s_tim5.h"
+// #include "stm8s_tim6.h"
 #endif  /* (STM8S903) || (STM8AF622x) */
 #if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined(STM8S103) ||\
     defined(STM8S003) || defined(STM8S001) || defined(STM8S903) || defined (STM8AF52Ax) || defined (STM8AF62Ax)
- #include "stm8s_uart1.h"
+// #include "stm8s_uart1.h"
 #endif /* (STM8S208) || (STM8S207) || (STM8S103) || (STM8S001) || (STM8S903) || (STM8AF52Ax) || (STM8AF62Ax) */
 #if defined(STM8S105) || defined(STM8S005) ||  defined (STM8AF626x)
- #include "stm8s_uart2.h"
+// #include "stm8s_uart2.h"
 #endif /* (STM8S105) || (STM8AF626x) */
 #if defined(STM8S208) ||defined(STM8S207) || defined(STM8S007) || defined (STM8AF52Ax) ||\
     defined (STM8AF62Ax)
- #include "stm8s_uart3.h"
+// #include "stm8s_uart3.h"
 #endif /* (STM8S208) || (STM8S207) || (STM8AF52Ax) || (STM8AF62Ax) */ 
 #if defined(STM8AF622x)                        /* SDCC patch: see https://github.com/tenbaht/sduino/tree/master/STM8S_StdPeriph_Driver */
- #include "stm8s_uart4.h"
+// #include "stm8s_uart4.h"
 #endif /* (STM8AF622x) */      
-#include "stm8s_wwdg.h"
+//#include "stm8s_wwdg.h"
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/


### PR DESCRIPTION
This significantly reduces the firmware size and also makes it possible to compile the firmware for a smaller 8Kbyte flash device (stm8sblue), where the firmware is only 565 bytes big, compared to the over 21kByte before.

For the environments 

```
stm8sblue
stm8sdisco
nucleo_8s207k8
nucleo_8s208rb
```

with [the old config file](https://github.com/platformio/platform-ststm8/blob/v1.0.3/examples/spl-blink/src/stm8s_conf.h):

```
Error: The program size (21730 bytes) is greater than maximum allowed (8192 bytes)
*** [checkprogsize] Explicit exit, status 1
RAM:   [          ]   0.0% (used 0 bytes from 1024 bytes)
Flash: [==========]  265.3% (used 21730 bytes from 8192 bytes)

RAM:   [          ]   0.0% (used 0 bytes from 2048 bytes)
Flash: [=======   ]  74.4% (used 24393 bytes from 32768 bytes)

RAM:   [          ]   0.1% (used 5 bytes from 6144 bytes)
Flash: [====      ]  37.9% (used 24839 bytes from 65536 bytes)

RAM:   [          ]   0.3% (used 21 bytes from 6144 bytes)
Flash: [==        ]  22.2% (used 29062 bytes from 131072 bytes)
```

With my updated file:

```
RAM:   [          ]   0.0% (used 0 bytes from 1024 bytes)
Flash: [=         ]   6.9% (used 565 bytes from 8192 bytes)

RAM:   [          ]   0.0% (used 0 bytes from 2048 bytes)
Flash: [          ]   1.7% (used 567 bytes from 32768 bytes)

RAM:   [          ]   0.0% (used 0 bytes from 6144 bytes)
Flash: [          ]   0.9% (used 569 bytes from 65536 bytes)

RAM:   [          ]   0.0% (used 0 bytes from 6144 bytes)
Flash: [          ]   0.4% (used 571 bytes from 131072 bytes)
```

The resulting firmare still works on my STM8S103F3 board. 